### PR TITLE
Loop and Pause features

### DIFF
--- a/jquery.ticker.js
+++ b/jquery.ticker.js
@@ -5,6 +5,7 @@
  * Copyright 2014 Benjamin Harris
  * Released under the MIT license
  */
+
 (function($) {
 
     // The ticker plugin
@@ -26,6 +27,7 @@
             var currentHeadlinePosition = 0;                   // The index of the current character in the current headline
             var firstOuterTick = true;                         // Whether this is the first time doing the outer tick
             var firstInnerTick = true;                         // Whether this is the first time doing the inner tick in this rendition of the outer one
+            
 
             var allowedTags = ['a', 'b', 'strong', 'span', 'i', 'em', 'u'];
 
@@ -65,7 +67,7 @@
                 }
 
                 outerTimeoutId = setTimeout(function () {
-                    if (opts.pauseOnHover && tickerContainer.hasClass('hover')) {
+                    if (opts.pauseOnHover && tickerContainer.hasClass('hover') || tickerContainer.hasClass('pause')) {
                         // User is hovering over the ticker and pause on hover is enabled
                         clearTimeout(innerTimeoutId);
                         outerTick();
@@ -89,7 +91,7 @@
                     return;
                 }
 
-                if (opts.finishOnHover && opts.pauseOnHover && tickerContainer.hasClass('hover') && currentHeadlinePosition <= headlines[currentHeadline].length) {
+                if (opts.finishOnHover && opts.pauseOnHover && tickerContainer.hasClass('hover') && currentHeadlinePosition <= headlines[currentHeadline].length || tickerContainer.hasClass('pause')) {
                     // Let's quickly complete the headline
                     // This is outside the timeout because we want to do this instantly without the pause
 
@@ -104,7 +106,7 @@
                 else {
                     // Handle as normal
                     innerTimeoutId = setTimeout(function () {
-                        if (opts.pauseOnHover && tickerContainer.hasClass('hover')) {
+                        if (opts.pauseOnHover && tickerContainer.hasClass('hover') || tickerContainer.hasClass('pause')) {
                             // User is hovering over the ticker and pause on hover is enabled
                             clearTimeout(innerTimeoutId);
                             innerTick();
@@ -124,8 +126,11 @@
                     currentHeadlinePosition = 0;
 
                     // Reset the headline and character positions if we've cycled through all the headlines
-                    if (currentHeadline == headlines.length) currentHeadline = 0;
-
+                    if (currentHeadline == headlines.length) {
+                        currentHeadline = 0;
+                        if (opts.onAdvanceLooped) opts.onAdvanceLooped();
+                    }
+                    
                     // STOP! We've advanced a headline. Now we just need to pause.
                     clearTimeout(innerTimeoutId);
                     clearTimeout(outerTimeoutId);
@@ -135,6 +140,8 @@
 
             // Do the individual ticks
             function tick() {
+
+
                 // Now let's update the ticker with the current tick string
                 if (currentHeadlinePosition === 0 && opts.fade) {
                     clearTimeout(innerTimeoutId);


### PR DESCRIPTION
Added onAdvanceLooped option to hook when the headers loop  back around.
Made it so the `pause` class will also pause the ticker (instead of just the hover).

Example of Loop
```js
$('.ticker').ticker({
                itemSpeed: itemSpeed,
                onAdvanceLooped: function() { 
                    if (!has_swapped)
                    {
                        setTimeout(nextOperator, itemSpeed);
                        has_swapped = true;
                    }
                },
            });
```


Example of pause
```js
$(prev).find('.ticker').addClass('pause');
```